### PR TITLE
bugfix: skip_type_checking just returns all files

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -23,6 +23,8 @@ pub(crate) fn get_file_iter(
                 Err(_) => {
                     eprintln!("skip {}", &f_path.display())
                 }
+            } else {
+                v.push(PathBuf::from(f_path));
             }
         }
     }

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -23,9 +23,9 @@ pub(crate) fn get_file_iter(
                 Err(_) => {
                     eprintln!("skip {}", &f_path.display())
                 }
-            } else {
-                v.push(PathBuf::from(f_path));
             }
+        } else {
+            v.push(PathBuf::from(f_path));
         }
     }
     Ok(v)


### PR DESCRIPTION
Therefor the path must be pushed onto the vector without type checking