### PR TITLE
Refactor metadata to a more concise representation (#14)

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::io;
 use std::os::unix::prelude::MetadataExt;
 use std::{error::Error, path::Path};
+use std::fmt::Display;
+use std::fs::metadata;
 
 #[derive(Debug)]
 pub struct Metadata {
@@ -25,12 +27,12 @@ impl MetadataError {
     }
 
     fn from_string(message: String) -> Self {
-        MetadataError { message: message }
+        MetadataError { message }
     }
 }
 
 // Display implementation is required for std::error::Error.
-impl fmt::Display for MetadataError {
+impl Display for MetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Metadata error: {}", self.message)
     }
@@ -50,14 +52,53 @@ impl From<io::Error> for MetadataError {
     }
 }
 
-fn get_date_time_created(path: &Path) -> Result<chrono::DateTime<FixedOffset>, MetadataError> {
-    Ok(FixedOffset::west(0).timestamp(fs::metadata(path)?.ctime(), 0))
+fn result_to_option<T, E: Error>(res: Result<T, E>, checkpoint: String) -> Option<T> {
+    match res {
+        Ok(t) => Some(t),
+        Err(e) => {
+            eprint!("Error occurred during {}: {}", checkpoint, e)
+        }
+    }
 }
 
-fn convert_exif_date_time_to_chrono_date_time_fixed_offset(
-    exif_date_time: exif::DateTime,
-) -> Result<chrono::DateTime<FixedOffset>, MetadataError> {
-    let offset = match exif_date_time.offset {
+fn open_file(path: &Path) -> Option<fs::File> {
+    result_to_option(fs::File::open(path), "opening file " + path.display())
+}
+
+fn get_date_time_created(path: &Path) -> Result<DateTime<FixedOffset>, MetadataError> {
+    Ok(FixedOffset::west(0).timestamp(metadata(path)?.ctime(), 0))
+}
+
+fn get_exif_metadata(file: fs::File, file_name: &String) -> Option<Exif> {
+    let mut bufreader = io::BufReader::new(&file);
+    let exif_reader = exif::Reader::new();
+    result_to_option(
+        exif_reader.read_from_container(&mut bufreader),
+        "extracting exif metadata for " + file_name
+    )
+}
+
+fn get_exif_date_time_field(exif: Exif, tag: Tag, file_name: &String)
+                            -> Option<exif::DateTime> {
+   exif.get_field(tag, In::PRIMARY)
+        .map(|field| {
+            match field.value {
+                Value::Ascii(ref v) => result_to_option(
+                    exif::DateTime::from_ascii(&v[0]),
+                    "converting exif field " + tag + " to date time"
+                ),
+                _ => {
+                    eprintln!("Exif field {} is not ascii in file {}", tag, file_name);
+                    None
+                }
+            }
+        }).flatten()
+}
+
+fn from_exif_to_chrono_date_time(exif_fate_time: exif::DateTime, file_name: &String)
+    -> Option<DateTime<FixedOffset>> {
+
+    let offset = match exif_fate_time.offset {
         Some(offset_minutes) => FixedOffset::west((offset_minutes * 60).into()),
         None => FixedOffset::west(0),
     };
@@ -76,49 +117,33 @@ fn convert_exif_date_time_to_chrono_date_time_fixed_offset(
         );
 
     match maybe_date {
-        chrono::LocalResult::Single(date) => Ok(date),
-        chrono::LocalResult::Ambiguous(_, _) => Err(MetadataError::from_str("Ambiguous date")),
-        chrono::LocalResult::None => Err(MetadataError {
-            message: "Invalid date".to_string(),
-        }),
+        chrono::LocalResult::Single(date) => Some(date),
+        chrono::LocalResult::Ambiguous(_, _) => {
+            eprintln!("Date time {} in {} was ambiguous", file_name, exif_fate_time);
+            None
+        },
+        chrono::LocalResult::None => {
+            eprintln!("Date time {} in {} was invalid", file_name, exif_fate_time);
+            None
+        }
     }
 }
 
-fn extract_date_time_exif_field(
-    exif: &Exif,
-    tag: Tag,
-) -> Result<Option<chrono::DateTime<FixedOffset>>, MetadataError> {
-    match exif.get_field(tag, In::PRIMARY) {
-        Some(field) => match field.value {
-            Value::Ascii(ref v) => match convert_exif_date_time_to_chrono_date_time_fixed_offset(
-                exif::DateTime::from_ascii(&v[0])?,
-            ) {
-                Ok(date_time) => Ok(Some(date_time)),
-                Err(err) => Err(err),
-            },
-            _ => Err(MetadataError {
-                message: "Exif date field is not ascii".to_string(),
-            }),
-        },
-        None => Ok(None),
-    }
+fn get_date_time_taken(path: &Path) -> Option<DateTime<FixedOffset>> {
+    let file_name = path.display().to_string();
+    open_file(path)
+        .map(|file| get_exif_metadata(file, &file_name)).flatten()
+        .map(|exif|
+            get_exif_date_time_field(exif, Tag::DateTimeOriginal, &file_name)
+        ).flatten()
+        .map(|exif_date_time|
+            from_exif_to_chrono_date_time(exif_date_time, &file_name)
+        ).flatten()
 }
 
 pub fn read_metadata(path: &Path) -> Result<Metadata, MetadataError> {
     let date_time_created = get_date_time_created(path)?;
-
-    let file = std::fs::File::open(path)?;
-    let mut bufreader = std::io::BufReader::new(&file);
-    let exifreader = exif::Reader::new();
-
-    let date_time_taken = match exifreader.read_from_container(&mut bufreader) {
-        Ok(exif) => extract_date_time_exif_field(&exif, Tag::DateTimeOriginal)?,
-        Err(err) => {
-            eprintln!("Could not read EXIF data: {}", err);
-            None
-        }
-    };
-
+    let date_time_taken = get_date_time_taken(path);
     Ok(Metadata {
         date_time_created,
         date_time_taken,


### PR DESCRIPTION
I wanted to play around with Rust and see if I can simplify a bit the extraction of the date time original and standardize the way we handle converting an error to an option.

What do you think?