### PR TITLE
skip check if directories are images/videos

### DIFF
--- a/src/mimetype.rs
+++ b/src/mimetype.rs
@@ -1,11 +1,11 @@
 use std::{fs, io, path::Path};
 
 /// image_or_video determines whether a given path is an image or video file
-pub fn image_or_video<P: AsRef<Path>>(filename: &P) -> Result<bool, io::Error> {
-    if fs::metadata(filename)?.is_dir() {
+pub fn image_or_video<P: AsRef<Path>>(path: &P) -> Result<bool, io::Error> {
+    if fs::metadata(path)?.is_dir() {
         Ok(false)
     } else {
-        match infer::get_from_path(filename) {
+        match infer::get_from_path(path) {
             Ok(Some(info)) if info.matcher_type() == infer::MatcherType::Image => Ok(true),
             Ok(Some(info)) if info.matcher_type() == infer::MatcherType::Video => Ok(true),
             Ok(_) => Ok(false),

--- a/src/mimetype.rs
+++ b/src/mimetype.rs
@@ -1,11 +1,15 @@
-use std::{io, path::Path};
+use std::{fs, io, path::Path};
 
 /// image_or_video determines whether a given path is an image or video file
 pub fn image_or_video<P: AsRef<Path>>(filename: &P) -> Result<bool, io::Error> {
-    match infer::get_from_path(filename) {
-        Ok(Some(info)) if info.matcher_type() == infer::MatcherType::Image => Ok(true),
-        Ok(Some(info)) if info.matcher_type() == infer::MatcherType::Video => Ok(true),
-        Ok(_) => Ok(false),
-        Err(e) => Err(e),
+    if fs::metadata(filename)?.is_dir() {
+        Ok(false)
+    } else {
+        match infer::get_from_path(filename) {
+            Ok(Some(info)) if info.matcher_type() == infer::MatcherType::Image => Ok(true),
+            Ok(Some(info)) if info.matcher_type() == infer::MatcherType::Video => Ok(true),
+            Ok(_) => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 }


### PR DESCRIPTION
When scanning provided path for images/videos now it will exclude directories from being checked.
Better way it would be to add another match arm checking if error is `IsADirectory` type, however this `io::ErrorKind` enum variant hasn't been stabilized yet: [issue](https://github.com/rust-lang/rust/issues/86442) therefore we need to check directories differently.
closes #23 